### PR TITLE
Fixes path for node_modules files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ npm install bekk/remark
 
 
 ```html
-<link href="node_modules/remark/dist/bekk.css" type="text/css" rel="stylesheet">
-<script src="node_modules/remark/vendor/remark-0.11.0.min.js" type="text/javascript"></script>
+<link href="node_modules/remark-bekk/dist/bekk.css" type="text/css" rel="stylesheet">
+<script src="node_modules/remark-bekk/vendor/remark-0.11.0.min.js" type="text/javascript"></script>
 <script type="text/javascript">
   var slideshow = remark.create({
     ratio: '16:9',


### PR DESCRIPTION
As the name in `package.json` is `remark-bekk` (and what it should be, as it's not `remark` it self), the `node_modules` directory will be named `remark-bekk`.
